### PR TITLE
Dialog box to set write permissions to J2PC to open apps in landscape…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.example.jumptopc">
 
+    <uses-permission android:name="android.permission.WRITE_SETTINGS"
+        tools:ignore="ProtectedPermissions" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
… mode

The feature is to open apps inside J2PC in landscape mode. If the permissions are not set, it opens a dialog box to let user grant the permission.

The case where the user denies to give permission needs to be discussed and handled differently.